### PR TITLE
register demo.pygeoapi in alternative search engines

### DIFF
--- a/services/home/app/templates/BingSiteAuth.xml
+++ b/services/home/app/templates/BingSiteAuth.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<users>
+	<user>327B1F75FEFE86E746A035394C66C39D</user>
+</users>

--- a/services/home/app/templates/robots.txt
+++ b/services/home/app/templates/robots.txt
@@ -1,0 +1,8 @@
+User-agent: *
+Disallow: *f=json*
+Disallow: *f=xml*
+Disallow: *f=gpkg*
+Disallow: *f=kml*
+Disallow: *f=geojson*
+Disallow: *f=json-ld*
+Disallow: /stable

--- a/services/home/app/templates/yandex_b99f962d1e52d84f.html
+++ b/services/home/app/templates/yandex_b99f962d1e52d84f.html
@@ -1,0 +1,6 @@
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    </head>
+    <body>Verification: b99f962d1e52d84f</body>
+</html>


### PR DESCRIPTION
these files identify pygeoapi@gmail.com as the owner of demo.pygeoapi.io, to access the yandex and bing search console.

added robots.txt file (to disallow non-html encodings)


