### PR TITLE
add api-catalog support

### DIFF
--- a/services/home/app/config.py
+++ b/services/home/app/config.py
@@ -1,7 +1,16 @@
 import logging
 import os
 
+base_url = 'https://demo.pygeoapi.io'
+
 # local config, change on server for real config
 config = {
     'loglevel': int(os.getenv('ADMIN_LOG_LEVEL', logging.DEBUG))
 }
+
+services = [
+    {'href': '/master', 'title': "pygeoapi - latest GitHub 'master' version"},
+    {'href': '/stable', 'title': 'pygeoapi - latest stable version'},
+    {'href': '/cite', 'title': "pygeoapi - CITE endpoint - latest GitHub 'master' version"},  # noqa
+    {'href': '/covid-19', 'title': "pygeoapi - COVID-19 endpoint - latest GitHub 'master' version"}  # noqa
+]

--- a/services/home/app/index.py
+++ b/services/home/app/index.py
@@ -58,7 +58,7 @@ def api_catalog():
     for service in services:
         url = f"{base_url}{service['href']}"
         response['linkset'].append({
-            'anchor': service['href'],
+            'anchor': url,
             'service-desc': [{
                 'href': f'{url}/openapi?f=json',
                 'title': f"{service['title']} (JSON)",

--- a/services/home/app/templates/home.html
+++ b/services/home/app/templates/home.html
@@ -11,7 +11,7 @@
     <table style="width: auto;" class="table table-bordered table-condensed table-responsive">
         <thead>
         <tr>
-            <th width="50%">Demonstrations</th>
+            <th width="50%">Demonstrations (<a href="{{ url_for('api_catalog') }}">API Catalog</a>)</th>
         </tr>
         </thead>
 

--- a/services/home/app/templates/home.html
+++ b/services/home/app/templates/home.html
@@ -14,18 +14,13 @@
             <th width="50%">Demonstrations</th>
         </tr>
         </thead>
+
+        {% for service in services %}
         <tr>
-            <td><a target="_blank" href="/master" class="btn btn-success">pygeoapi - latest GitHub 'master' version</a></td>
+            <td><a target="_blank" href="{{ service['href'] }}" class="btn btn-success">{{ service['title'] }}</a></td>
         </tr>
-        <tr>
-            <td><a target="_blank" href="/stable" class="btn btn-success">pygeoapi - latest stable version</a></td>
-        </tr>
-        <tr>
-            <td><a target="_blank" href="/cite" class="btn btn-success">pygeoapi - CITE endpoint - latest GitHub 'master' version</a></td>
-        </tr>
-        <tr>
-            <td><a target="_blank" href="/covid-19" class="btn btn-success">pygeoapi - COVID-19 endpoint - latest GitHub 'master' version</a></td>
-        </tr>
+        {% endfor %}
+
         <tr>
             <td><a target="_blank" href="https://opengeogroep.github.io/ogc-api-features-testclient/src/index.html" class="btn btn-success">Test Client - by OpenGeoGroep</a></td>
         </tr>

--- a/services/home/app/templates/home.html
+++ b/services/home/app/templates/home.html
@@ -11,7 +11,7 @@
     <table style="width: auto;" class="table table-bordered table-condensed table-responsive">
         <thead>
         <tr>
-            <th width="50%">Demonstrations (<a href="{{ url_for('api_catalog') }}">API Catalog</a>)</th>
+            <th width="50%">Demonstrations (<a href="{{ url_for('api_catalog') }}" rel="api-catalog">API Catalog</a>)</th>
         </tr>
         </thead>
 


### PR DESCRIPTION
This PR adds a setup for [IETF API Catalog](https://datatracker.ietf.org/doc/draft-ietf-httpapi-api-catalog/08/) support.