### PR TITLE
Increased the limits parameter on cite instance

### DIFF
--- a/services/pygeoapi_cite/pygeoapi/cite.config.yml
+++ b/services/pygeoapi_cite/pygeoapi/cite.config.yml
@@ -9,7 +9,7 @@ server:
     cors: true
     pretty_print: true
     limits:
-        max_items: 10
+        max_items: 50
     # templates: /path/to/templates
     map:
       url: https://tile.openstreetmap.org/{z}/{x}/{y}.png


### PR DESCRIPTION
The cite instance is failing the compliance tests: https://github.com/geopython/demo.pygeoapi.io/issues/65

The issue is that the number of maximum items set on the server limits is lower than the one used in the tests (50).

https://github.com/geopython/demo.pygeoapi.io/blob/1645a219fd8767149c7212d681abc72735a7cd1f/services/pygeoapi_cite/pygeoapi/cite.config.yml#L10-L12

This PR addresses that, by bumping this value to 50.

With this change, the pygeoapi cite instance successfully passes the compliance tests. This is the output of teamengine, after the change:

> Results for session s0001
> Test Name: ogcapi-features-1.0
> Test version: 1.6
> Time: 2025-06-25T13:37:21.483Z
> 
> Test INPUT:
> noofcollections : 3
> Tested Instance : http://pygeoapi:80
> 
> Result:
> Passed Core conformance classes (Implementations passing these classes can be certified): Yes
> Number of conformance classes tested: 2
> Number of conformance classes passed: 2
> Number of conformance classes failed: 0
> 