### PR TITLE
Added storage_crs parameter to the Maps collection

### DIFF
--- a/services/pygeoapi_master/local.config.yml
+++ b/services/pygeoapi_master/local.config.yml
@@ -1012,6 +1012,7 @@ resources:
               format:
                     name: png
                     mimetype: image/png
+              storage_crs: http://www.opengis.net/def/crs/EPSG/0/4326
 
     hello-world:
         type: process


### PR DESCRIPTION
This parameter becomes supported with [this](https://github.com/geopython/pygeoapi/pull/2308) PR, and it is important to avoid using the default CRS (CRS84), which is not supported in this particular WMS instance.